### PR TITLE
Compatibility patch for Flare Stack

### DIFF
--- a/Thaumaturgic-Machinations/TM-functions.lua
+++ b/Thaumaturgic-Machinations/TM-functions.lua
@@ -356,7 +356,7 @@ function TM.inherit_helper(dat_recipe, recipe)
 		local tier = TM.GetTier(value.name)
 		if tier ~= nil and tier >= 0 then isaspect = " (is an aspect)" end
 		local result_amount = dat_recipe.result_count
-		if result_amount == nil then 
+		if result_amount == nil or not next(dat_recipe.results) then 
 			if dat_recipe.results == nil then
 				result_amount = 1
 			else


### PR DESCRIPTION
Update TM.inherit_helper to be compatible with recipes with a non-nil, empty results table.
This is a naive technical solution. I haven't taken the time and effort to understand the consequences of assigning a result_amount to a recipe designed to destroy items.  
Fixes #57 