### PR TITLE
Fix crash on equipping armor in versions 0.17.35+

### DIFF
--- a/Thaumaturgic-Machinations/control.lua
+++ b/Thaumaturgic-Machinations/control.lua
@@ -104,7 +104,7 @@ end)
 script.on_event(defines.events.on_player_armor_inventory_changed, function(event)
  
   	local player = game.players[event.player_index]
-	local armor = player.get_inventory(defines.inventory.player_armor)
+	local armor = player.get_inventory(defines.inventory.character_armor)
 	
 	-- check if an armor is equiped, before we do anything
 	-- else we set the players inventory bonus count to zero


### PR DESCRIPTION
[Factorio 0.17.35 included an API change](https://forums.factorio.com/viewtopic.php?t=70188) that broke the on_player_armor_inventory_changed response function. This change updates the old defunct defines.inventory.player_armor to the new defines.inventory.character_armor